### PR TITLE
Add windows support and better support for using custom depth images

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ pip install git+https://github.com/huggingface/transformers.git@main
 ```
 
 ## Thanks
-Code for venv setup borrowed from https://github.com/victorchall/EveryDream2trainer
+Code for windows venv setup and utils/patch_bnb.py borrowed from https://github.com/victorchall/EveryDream2trainer

--- a/README.md
+++ b/README.md
@@ -10,3 +10,6 @@ At the time of writing, `StableDiffusionDepth2ImgPipeline` is supported only on 
 pip uninstall -y transformers
 pip install git+https://github.com/huggingface/transformers.git@main
 ```
+
+## Thanks
+Code for venv setup borrowed from https://github.com/victorchall/EveryDream2trainer

--- a/activate_venv.bat
+++ b/activate_venv.bat
@@ -1,0 +1,1 @@
+call venv/scripts/activate.bat

--- a/example_cli_training_launch
+++ b/example_cli_training_launch
@@ -1,0 +1,21 @@
+accelerate launch ^
+--mixed_precision=bf16 ^
+--num_processes=1 ^
+--num_machines=1 ^
+train_dreambooth.py ^
+--mixed_precision=bf16 ^
+--pretrained_model_name_or_path=stabilityai/stable-diffusion-2-depth  ^
+--pretrained_txt2img_model_name_or_path="stabilityai/stable-diffusion-2-1-base" ^
+--train_text_encoder ^
+--instance_data_dir=data/input ^
+--class_data_dir=data/style ^
+--output_dir=data/output ^
+--instance_prompt="<your_instance_prompt>" ^
+--resolution=512 ^
+--train_batch_size=4 ^
+--gradient_accumulation_steps=1 ^
+--learning_rate=1e-6 ^
+--lr_scheduler="constant" ^
+--lr_warmup_steps=0 ^
+--max_train_steps=2000 ^
+--use_8bit_adam

--- a/train_dreambooth.py
+++ b/train_dreambooth.py
@@ -329,6 +329,7 @@ class DreamBoothDataset(Dataset):
         self.depth_image_transforms = transforms.Compose(
             [
                 transforms.Resize(size // self.vae_scale_factor, interpolation=transforms.InterpolationMode.BILINEAR),
+                transforms.Grayscale(num_output_channels=1),
                 transforms.ToTensor()
             ]
         )

--- a/train_dreambooth.py
+++ b/train_dreambooth.py
@@ -4,6 +4,7 @@ import hashlib
 import itertools
 import math
 import os
+import re
 import warnings
 from pathlib import Path
 from typing import Optional
@@ -101,7 +102,7 @@ def parse_args(input_args=None):
         "--instance_prompt",
         type=str,
         default=None,
-        required=True,
+        required=False,
         help="The prompt with identifier specifying the instance",
     )
     parser.add_argument(
@@ -339,6 +340,7 @@ class DreamBoothDataset(Dataset):
     def __getitem__(self, index):
         example = {}
         instance_image_path = self.instance_images_path[index % self.num_instance_images]
+        instance_prompt = self.instance_prompt if self.instance_prompt not in ["", None] else re.sub(r'\..*$', '', instance_image_path.name)
         instance_depth_image_path = get_depth_image_path(instance_image_path)
         instance_image = Image.open(instance_image_path)
         instance_depth_image = Image.open(instance_depth_image_path)
@@ -347,7 +349,7 @@ class DreamBoothDataset(Dataset):
         example["instance_images"] = self.image_transforms(instance_image)
         example["instance_depth_images"] = self.depth_image_transforms(instance_depth_image)
         example["instance_prompt_ids"] = self.tokenizer(
-            self.instance_prompt,
+            instance_prompt,
             truncation=True,
             padding="max_length",
             max_length=self.tokenizer.model_max_length,

--- a/train_dreambooth.py
+++ b/train_dreambooth.py
@@ -373,32 +373,34 @@ class DreamBoothDataset(Dataset):
         return example
 
 
-def collate_fn(examples, with_prior_preservation=False):
-    input_ids = [example["instance_prompt_ids"] for example in examples]
-    pixel_values = [example["instance_images"] for example in examples]
-    depth_values = [example["instance_depth_images"] for example in examples]
+class Collater:
+    def __init__(self, with_prior_preservation=False):
+        self.with_prior_preservation = with_prior_preservation
+    def __call__(self, examples):
+        input_ids = [example["instance_prompt_ids"] for example in examples]
+        pixel_values = [example["instance_images"] for example in examples]
+        depth_values = [example["instance_depth_images"] for example in examples]
 
-    # Concat class and instance examples for prior preservation.
-    # We do this to avoid doing two forward passes.
-    if with_prior_preservation:
-        input_ids += [example["class_prompt_ids"] for example in examples]
-        pixel_values += [example["class_images"] for example in examples]
-        depth_values += [example["class_depth_images"] for example in examples]
+        # Concat class and instance examples for prior preservation.
+        # We do this to avoid doing two forward passes.
+        if self.with_prior_preservation:
+            input_ids += [example["class_prompt_ids"] for example in examples]
+            pixel_values += [example["class_images"] for example in examples]
+            depth_values += [example["class_depth_images"] for example in examples]
 
-    pixel_values = torch.stack(pixel_values)
-    pixel_values = pixel_values.to(memory_format=torch.contiguous_format).float()
+        pixel_values = torch.stack(pixel_values)
+        pixel_values = pixel_values.to(memory_format=torch.contiguous_format).float()
 
-    depth_values = torch.stack(depth_values)
-    depth_values = depth_values.to(memory_format=torch.contiguous_format).float()
+        depth_values = torch.stack(depth_values)
+        depth_values = depth_values.to(memory_format=torch.contiguous_format).float()
 
-    input_ids = torch.cat(input_ids, dim=0)
+        input_ids = torch.cat(input_ids, dim=0)
 
-    batch = {
-        "input_ids": input_ids,
-        "pixel_values": pixel_values,
-        "depth_values": depth_values
-    }
-    return batch
+        return {
+            "input_ids": input_ids,
+            "pixel_values": pixel_values,
+            "depth_values": depth_values,
+        }
 
 
 class PromptDataset(Dataset):
@@ -632,11 +634,12 @@ def main(args):
         center_crop=args.center_crop,
     )
 
+    collater = Collater(with_prior_preservation=args.with_prior_preservation)
     train_dataloader = torch.utils.data.DataLoader(
         train_dataset,
         batch_size=args.train_batch_size,
         shuffle=True,
-        collate_fn=lambda examples: collate_fn(examples, args.with_prior_preservation),
+        collate_fn=collater,
         num_workers=1,
     )
 

--- a/utils/patch_bnb.py
+++ b/utils/patch_bnb.py
@@ -1,0 +1,133 @@
+"""
+Copyright [2022] Victor C Hall
+
+Licensed under the GNU Affero General Public License;
+You may not use this code except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gnu.org/licenses/agpl-3.0.en.html
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+# see: https://github.com/TimDettmers/bitsandbytes/issues/30 for explanation
+import sys
+import os
+from subprocess import check_output
+import shutil
+
+_CEXT_PATCH = "            self.lib = ct.cdll.LoadLibrary(str(binary_path))"
+_MAIN_PATCH = "    return 'libbitsandbytes_cuda116.dll'"
+
+def patch_main():
+    bnbpath_main = "venv/Lib/site-packages/bitsandbytes/cuda_setup/main.py"
+    try: 
+        with open(bnbpath_main, "r") as f:
+            contents = f.read()
+            contents = contents.split('\n')
+    except Exception as ex:
+        print(f"cannot find bitsandbytes install, aborting, error: {ex}")
+        return False
+
+    main_patched = False
+
+    for i, line in enumerate(contents):
+        if i == 112:
+            if line != _MAIN_PATCH:
+                contents[i] = _MAIN_PATCH
+                main_patched = True
+            else:
+                print(" *** Already patched!")
+                main_patched = True
+
+    assert main_patched, "unable to patch bitsandbytes, may be mismatched version, requires 0.35.0"
+
+    with open(bnbpath_main, "w") as f:
+        for line in contents:
+            f.write(line + "\n")
+        #print(contents)
+    
+    return main_patched
+
+def patch_cext():    
+    bnbpath_cextension = "venv/Lib/site-packages/bitsandbytes/cextension.py"
+    try: 
+        with open(bnbpath_cextension, "r") as f:
+            contents = f.read()
+            contents = contents.split('\n')
+    except Exception as ex:
+        print(f"cannot find bitsandbytes install, aborting, error: {ex}")
+        return False
+
+    cext_patched = False
+
+    for i, line in enumerate(contents):
+        # update both lines 28 and 31 to be sure correct dll is returned
+        if (i == 30 or i == 27):
+            if line != _CEXT_PATCH:
+                contents[i] = _CEXT_PATCH
+                cext_patched = True
+            else:
+                cext_patched = True
+
+    assert cext_patched, "unable to patch bitsandbytes, died midprocess, something broke and may need to reinstall bitsandbytes==0.35.0"
+
+    with open(bnbpath_cextension, "w") as f:
+        for line in contents:
+            f.write(line + "\n")
+        #print(contents)
+
+    return cext_patched
+
+def iswindows():
+    return sys.platform.startswith('win')
+
+def error():
+    print("Somethnig went wrong trying to patch bitsandbytes, aborting")
+    print("make sure your venv is activated and try again")
+    print("or if activated try: ")
+    print("    pip install bitsandbytes==0.35.0")
+    raise RuntimeError("** FATAL ERROR: unable to patch bitsandbytes for Windows env")
+
+def check_dlls():
+    dll_exists = os.path.exists("venv/Lib/site-packages/bitsandbytes/libbitsandbytes_cuda116.dll")
+    if not dll_exists:
+        if not os.path.exists("tmp/bnb_cache"):
+            check_output("git clone https://github.com/DeXtmL/bitsandbytes-win-prebuilt tmp/bnb_cache", shell=True)
+        shutil.copy("tmp/bnb_cache/libbitsandbytes_cuda116.dll", "venv/Lib/site-packages/bitsandbytes/libbitsandbytes_cuda116.dll")
+    dll_exists = os.path.exists("venv/Lib/site-packages/bitsandbytes/libbitsandbytes_cuda116.dll")
+    return dll_exists
+
+def main():
+    """
+    applies a patch for windows compatibility for bitsandbytes 0.35.0 for using their AdamW8bit optimizer
+    """
+    if iswindows():
+        print()
+        print(" *** Applying bitsandbytes patch for windows ***")
+        if not check_dlls():
+            print("unable to find bitsandbytes dll or clone them from git, aborting")
+            raise RuntimeError("** FATAL ERROR: unable to patch bitsandbytes for Windows env")
+
+        main_patched = patch_main()
+        cext_patched = patch_cext()
+        if main_patched and cext_patched:
+            try:
+                print(" *************************************************************")
+                print(" *** bitsandbytes windows patch applied, attempting import *** ")
+                import bitsandbytes
+                print(f" *** bitsandbytes patch succeeded, everything looks good!  ***")
+            except:
+                error()
+        else: 
+            error()
+    else:
+        print(" *** not using windows environment, skipping bitsandbytes patch ***")
+        return
+
+if __name__ == "__main__":
+    main()

--- a/windows_setup.cmd
+++ b/windows_setup.cmd
@@ -20,6 +20,7 @@ pip install -U -I --no-deps https://github.com/C43H66N12O12S2/stable-diffusion-w
 pip install pytorch-lightning==1.6.5
 pip install OmegaConf==2.2.3
 pip install numpy==1.23.5
+python utils/patch_bnb.py
 GOTO :eof
 
 :ERROR

--- a/windows_setup.cmd
+++ b/windows_setup.cmd
@@ -1,0 +1,32 @@
+python -m venv venv
+call "venv\Scripts\activate.bat"
+echo should be in venv here
+cd .
+python -m pip install --upgrade pip
+pip install torch==1.12.1+cu116 torchvision==0.13.1+cu116 --extra-index-url https://download.pytorch.org/whl/cu116
+pip install git+https://github.com/huggingface/transformers.git@main
+pip install diffusers[torch]==0.10.2
+pip install pynvml==11.4.1
+pip install bitsandbytes==0.35.0
+git clone https://github.com/DeXtmL/bitsandbytes-win-prebuilt tmp/bnb_cache
+pip install ftfy==6.1.1
+pip install aiohttp==3.8.3
+pip install tensorboard>=2.11.0
+pip install protobuf==3.20.1
+pip install wandb==0.13.6
+pip install pyre-extensions==0.0.23
+pip install -U -I --no-deps https://github.com/C43H66N12O12S2/stable-diffusion-webui/releases/download/f/xformers-0.0.14.dev0-cp310-cp310-win_amd64.whl
+::pip install "xformers-0.0.15.dev0+affe4da.d20221212-cp38-cp38-win_amd64.whl" --force-reinstall
+pip install pytorch-lightning==1.6.5
+pip install OmegaConf==2.2.3
+pip install numpy==1.23.5
+python utils/patch_bnb.py
+python utils/get_yamls.py
+GOTO :eof
+
+:ERROR
+echo Something blew up. Make sure Pyton 3.10.x is installed and in your PATH.
+
+:eof
+ECHO done
+pause

--- a/windows_setup.cmd
+++ b/windows_setup.cmd
@@ -20,8 +20,6 @@ pip install -U -I --no-deps https://github.com/C43H66N12O12S2/stable-diffusion-w
 pip install pytorch-lightning==1.6.5
 pip install OmegaConf==2.2.3
 pip install numpy==1.23.5
-python utils/patch_bnb.py
-python utils/get_yamls.py
 GOTO :eof
 
 :ERROR


### PR DESCRIPTION
Uses a slightly modified venv from https://github.com/victorchall/EveryDream2trainer for windows xformers and 8bit adam support. 

Changes the collate_fn in the dataloader from being a lambda function to a class method in order to avoid windows pickling errors. 

Added example cli training launch command. 

If you want to use custom depth images, you just make sure the depth has the same name as the matching image but with '_depth' appended to it. Images must be in .png format. Depth images will now automatically convert to grayscale in order to accommodate loading custom ones.

Added ability to use image filenames as prompts (leave instance_prompt a blank string or don't include in arguments)

Let me know if you have any questions!

